### PR TITLE
Create rules folder when downloading

### DIFF
--- a/bin/akamai-visitor-prioritization
+++ b/bin/akamai-visitor-prioritization
@@ -487,6 +487,8 @@ def download(args):
                 # Update the local copy to latest details
                 new_policy_folder = 'rules'
                 if output_file:
+                   if not os.path.exists(new_policy_folder):
+                        os.makedirs(new_policy_folder)
                     output_filename = os.path.join(
                         new_policy_folder, output_file)
                 else:


### PR DESCRIPTION
In the download command, there is no check to create the ```/rules``` folder if it is not already present. However, the code has been written to always write the file to this folder.

So when a user does specify the folder name to use, an error is generated saying ```No such file or directory```. The fix I've made is to correct this bug.