### PR TITLE
Allow and disable added. --allrules option added

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,7 +31,8 @@ Main program that wraps this functionality in a command line utility:
 * [setup](#setup)
 * [list](#list)
 * [show](#show)
-* [throttle](#throttle)
+* [allow](#allow)
+* [disable](#disable)
 * [activate](#activate)
 * [download](#download)
 * [create-version](#create-version)
@@ -70,25 +71,42 @@ The flags of interest for show are:
 
 ```
 
-### throttle
+### allow
 Make an actual change to percentage value for a specific rule name in the policy.
 
 ```bash
-%  akamai-visitor-prioritization throttle --percent 50 --policyName samplePolicyName --rule 'ruleName' --network staging
-%  akamai-visitor-prioritization throttle --percent -1 --policyName samplePolicyName --rule 'ruleName' --network staging
-%  akamai-visitor-prioritization throttle --disable --policy samplePolicyName --rule 'ruleName' --network production
-%  akamai-visitor-prioritization throttle --disable --policy samplePolicyName --rule 'ruleName' --network production --force
-%  akamai-visitor-prioritization throttle --disable --policy samplePolicyName --rule 'ruleName' --network staging
+%  akamai-visitor-prioritization allow --percent 50 --policy samplePolicyName --rule 'ruleName' --network production
+%  akamai-visitor-prioritization allow --percent -1 --policy samplePolicyName --rule 'ruleName' --network staging
+%  akamai-visitor-prioritization allow --percent 100 --policy samplePolicyName --rule 'ruleName' --network production --force
+```
+
+The flags of interest for allow are:
+
+```
+--percent <value>       Acceptable values are -1 (= All to Waiting Room), 0 <= 100 (100 = everyone allowed)
+--policy <policyName>   Specified Visitor Prioritization Cloudlet policy name
+--rule <ruleName>       Name of rule in policy that should be changed. Use single quotes ('') in case rule name has spaces. If multiple rules exist for the same name, all of them will be updated.
+--network <network>     Either staging or production ; will make change based on latest version on that network
+--allrules              Apply this change to all rules in the policy without needing specific --rule name
+--force                 Use this flag if you want to proceed without confirmation (only for --network production)
+```
+
+### disable
+Disable or make inactive for a specific rule name in the policy.
+
+```bash
+%  akamai-visitor-prioritization disable --policy samplePolicyName --rule 'ruleName' --network production
+%  akamai-visitor-prioritization disable --policy samplePolicyName --rule 'ruleName' --network staging
+%  akamai-visitor-prioritization disable --policy samplePolicyName --allrules --network production --force
 ```
 
 The flags of interest for throttle are:
 
 ```
---percent <value>       Acceptable values are -1 (= All to Waiting Room), 0 <= 100 (100 = everyone allowed)
---disable               If specifed instead of --percent, disables the rule in the policy
 --policy <policyName>   Specified Visitor Prioritization Cloudlet policy name
 --rule <ruleName>       Name of rule in policy that should be changed. Use single quotes ('') in case rule name has spaces. If multiple rules exist for the same name, all of them will be updated.
 --network <network>     Either staging or production ; will make change based on latest version on that network
+--allrules              Apply this change to all rules in the policy without needing specific --rule name
 --force                 Use this flag if you want to proceed without confirmation (only for --network production)
 ```
 

--- a/bin/akamai-visitor-prioritization
+++ b/bin/akamai-visitor-prioritization
@@ -166,8 +166,6 @@ def cli():
     actions["throttle"] = create_sub_command(
         subparsers, "throttle", "Throttle traffic by rule name",
         [{"name": "percent", "help": "Throttle percentage (-1 to 100)"},
-         {"name": "disable", "help": "Disable all throttling",
-          "action": "store_true"},
          {"name": "network",
           "help": "Network to be activated on (case-insensitive).",
           "type": str.lower, "choices": {"staging", "production"}},
@@ -176,6 +174,39 @@ def cli():
               "Rule name to update (use 'single quotes' to honor "
               "spaces in rule name))"},
          {"name": "force", "help": "Do not prompt for user confirmation",
+          "action": "store_true"},
+         {"name": "allrules", "help": "Apply action on all rules",
+          "action": "store_true"}],
+        [{"name": "policy", "help": "Policy name"}])
+
+    actions["allow"] = create_sub_command(
+        subparsers, "allow", "Percentage of Traffic to be allowed to Origin. Same as throttle",
+        [{"name": "percent", "help": "Throttle percentage (-1 to 100)"},
+         {"name": "network",
+          "help": "Network to be activated on (case-insensitive).",
+          "type": str.lower, "choices": {"staging", "production"}},
+         {"name": "rule",
+          "help":
+              "Rule name to update (use 'single quotes' to honor "
+              "spaces in rule name))"},
+         {"name": "force", "help": "Do not prompt for user confirmation",
+          "action": "store_true"},
+         {"name": "allrules", "help": "Apply action on all rules",
+          "action": "store_true"}],
+        [{"name": "policy", "help": "Policy name"}])
+
+    actions["disable"] = create_sub_command(
+        subparsers, "disable", "Disable a rule within the policy",
+        [{"name": "network",
+          "help": "Network to be activated on (case-insensitive).",
+          "type": str.lower, "choices": {"staging", "production"}},
+         {"name": "rule",
+          "help":
+              "Rule name to update (use 'single quotes' to honor "
+              "spaces in rule name))"},
+         {"name": "force", "help": "Do not prompt for user confirmation",
+          "action": "store_true"},
+         {"name": "allrules", "help": "Apply action on all rules",
           "action": "store_true"}],
         [{"name": "policy", "help": "Policy name"}])
 
@@ -397,11 +428,19 @@ def show(args):
                                         root_logger.info(
                                             '       Match Type: ' + every_match_condition['matchType'])
                                         if 'matchValue' in every_match_condition:
-                                            root_logger.info(
-                                                '       Match Value: ' + every_match_condition['matchValue'])
+                                            if every_match_condition['negate'] is False:
+                                                root_logger.info(
+                                                    '       Match Value: ' + every_match_condition['matchValue'])
+                                            else:
+                                                root_logger.info(
+                                                    '       Match Value is NOT: ' + every_match_condition['matchValue'])
                                         elif 'objectMatchValue' in every_match_condition:
-                                            root_logger.info(
-                                                '       Match Value: ' + str(every_match_condition['objectMatchValue']['value']))
+                                            if every_match_condition['negate'] is False:
+                                                root_logger.info(
+                                                    '       Match Value: ' + str(every_match_condition['objectMatchValue']['value']))
+                                            else:
+                                                root_logger.info(
+                                                    '       Match Value is NOT: ' + str(every_match_condition['objectMatchValue']['value']))
 
                                         multiple_matches = 1
                                     # Check wthether rules is disabled, if yes
@@ -673,55 +712,51 @@ def activate(args):
 def throttle(args):
     base_url, session = init_config(args.edgerc, args.section)
 
+    command = sys.argv[1]
     policy = args.policy
     network = args.network
     rule = args.rule
-    percent = args.percent
-    disable = args.disable
     force = args.force
 
-    if not disable and not percent:
-        root_logger.info("One of --percent or --disable must be specified")
-        return 1
 
-    if disable and percent:
-        root_logger.info("One of --percent or --disable must be specified, not both")
-        return 1
+    if not command == 'disable':
+        percent = args.percent
+        if not percent:
+            root_logger.info("--percent must be specified")
+            return 1
+
 
     if not network:
         root_logger.info("--network must be specified")
         return 1
 
-    if not rule:
-        root_logger.info("--rule must be specified")
-        return 1
-
-    if percent:
-        if int(percent) < -1 or int(percent) > 100:
-            root_logger.info("Invalid --percent value, please specify a value between -1 and 100")
+    if not args.allrules:
+        if not rule:
+            root_logger.info("--rule or --allrules must be specified")
             return 1
 
+    if args.allrules and rule:
+        root_logger.info("--rule and --allrules cannot be specified together")
+        return 1
+
+    if not command == 'disable':
+        if percent:
+            if int(percent) < -1 or int(percent) > 100:
+                root_logger.info("Invalid --percent value, please specify a value between -1 and 100")
+                return 1
+
     if not force and network == "production":
-        if not disable:
-            root_logger.info(
-                'You are about to throttle ' +
-                rule +
-                ' at value = ' +
-                str(percent) +
-                ' for ' +
-                policy +
-                ' on the Akamai ' +
-                network +
-                ' network. Do you wish to continue? [y/N]')
-        else:
-            root_logger.info(
-                'You are about to disable ' +
-                rule +
-                ' for ' +
-                policy +
-                ' on the Akamai ' +
-                network +
-                ' network. Do you wish to continue? [y/N]')
+        root_logger.info(
+            'You are about to throttle ' +
+            rule +
+            ' at value = ' +
+            str(percent) +
+            ' for ' +
+            policy +
+            ' on the Akamai ' +
+            network +
+            ' network. Do you wish to continue? [y/N]')
+
 
         if str.lower(input()) != 'y':
             root_logger.info('Exiting...')
@@ -782,7 +817,11 @@ def throttle(args):
             rule_count = 0
             policy_details_to_modify = {}
             every_detail_of_policy = policy_details.json()
-            root_logger.info('\nSearching for Rule: ' + rule)
+            if rule:
+                root_logger.info('\nSearching for Rule: ' + rule)
+            else:
+                pass
+
             if 'matchRules' in every_detail_of_policy:
                 # Check whether it is null value
                 if every_detail_of_policy['matchRules'] is None:
@@ -796,11 +835,11 @@ def throttle(args):
                         if 'location' in every_match_rule:
                             del every_match_rule['location']
                         # Match the rule name (case insensitive)
-                        if every_match_rule['name'].lower() == rule.lower():
+                        if rule and every_match_rule['name'].lower() == rule.lower() or args.allrules:
                             # Update the throttle value now
                             rule_found = 1
                             rule_count = rule_count + 1
-                            if not disable:
+                            if not command == 'disable':
                                 every_match_rule['passThroughPercent'] = int(percent)
                                 # Check whether rules is disabled, if yes
                                 # enable it by deleting the disable entry
@@ -808,21 +847,39 @@ def throttle(args):
                                     del every_match_rule['disabled']
                             else:
                                 every_match_rule['disabled'] = True
+                    if rule:
+                        if command == 'disable':
+                            description = 'Created from v' + str(version) + \
+                                          ': ' + command + 'Rule = ' + rule \
+                                           + ' (Akamai CLI for Visitor Prioritization)'
+                        else:
+                            description = 'Created from v' + str(version) + \
+                                          ': ' + command + 'Rule = ' + rule + ' to value = ' \
+                                          + str(percent) + ' (Akamai CLI for Visitor Prioritization)'
+                    elif args.allrules:
+                        if command == 'disable':
+                            description = 'Created from v' + str(version) + \
+                                          ': Disabled All Rules (Akamai CLI for Visitor Prioritization)'
+                        else:
+                            description = 'Created from v' + str(version) + \
+                                          ': ' + command + ' All Rules to value = ' \
+                                          + str(percent) + ' (Akamai CLI for Visitor Prioritization)'
+
 
                     policy_details_to_modify['matchRules'] = every_detail_of_policy['matchRules']
-                    policy_details_to_modify['description'] = 'Created from v' + str(version) + \
-                                                              ': Throttle Rule = ' + rule + ' to value = ' \
-                                                              + str(percent) if not disable else "disabled" + \
-                                                              ' (Akamai CLI for Visitor Prioritization)'
+                    policy_details_to_modify['description'] = description
+
                     if rule_found == 0:
                         root_logger.info(
                             'Rule: ' + rule + ' is not found. Exiting...')
                         return 1
                     if rule_count == 1:
                         root_logger.info('1 rule has been found...')
-                    else:
+                    elif not args.allrules:
                         root_logger.info(
                             str(rule_count) + ' rules have been found...')
+                    else:
+                        root_logger.info('All rules have been updated...')
             else:
                 root_logger.info('No rules exist in the policy. Exiting...')
                 return 1
@@ -831,7 +888,7 @@ def throttle(args):
             policy_create_response = cloudlet_object.create_policy_version(
                 session, policy_id=policy_policy_id)
             root_logger.info(
-                '\nTrying to create a new version of this policy with updated rule throttle.')
+                '\nTrying to create a new version of this policy with updated rule(s).')
             if policy_create_response.status_code == 200 or 201:
                 new_version = policy_create_response.json()['version']
                 # Let us now update the rules with new throttle values
@@ -849,7 +906,7 @@ def throttle(args):
                     activation_response = cloudlet_object.activate_policy_version(
                         session, policy_policy_id, str(policy_update_response.json()['version']), network)
                     if activation_response.status_code == 200:
-                        root_logger.info('Success! Throttle change is live...')
+                        root_logger.info('Success! ' + command + ' change is live...')
                     else:
                         root_logger.info(
                             'Unable to activate, check for invalid version')
@@ -871,6 +928,14 @@ def throttle(args):
             return 1
 
     return 0
+
+
+def allow(args):
+    throttle(args)
+
+
+def disable(args):
+    throttle(args)
 
 
 def list(args=None):

--- a/bin/akamai-visitor-prioritization
+++ b/bin/akamai-visitor-prioritization
@@ -163,25 +163,10 @@ def cli():
           "type": str.lower, "choices": {"staging", "production"}},
          {"name": "version", "help": "Version number of the policy"}])
 
-    actions["throttle"] = create_sub_command(
-        subparsers, "throttle", "Throttle traffic by rule name",
-        [{"name": "percent", "help": "Throttle percentage (-1 to 100)"},
-         {"name": "network",
-          "help": "Network to be activated on (case-insensitive).",
-          "type": str.lower, "choices": {"staging", "production"}},
-         {"name": "rule",
-          "help":
-              "Rule name to update (use 'single quotes' to honor "
-              "spaces in rule name))"},
-         {"name": "force", "help": "Do not prompt for user confirmation",
-          "action": "store_true"},
-         {"name": "allrules", "help": "Apply action on all rules",
-          "action": "store_true"}],
-        [{"name": "policy", "help": "Policy name"}])
 
     actions["allow"] = create_sub_command(
-        subparsers, "allow", "Percentage of Traffic to be allowed to Origin. Same as throttle",
-        [{"name": "percent", "help": "Throttle percentage (-1 to 100)"},
+        subparsers, "allow", "Percentage of Traffic to be allowed to Origin.",
+        [{"name": "percent", "help": "Allow traffic percentage (-1 to 100)"},
          {"name": "network",
           "help": "Network to be activated on (case-insensitive).",
           "type": str.lower, "choices": {"staging", "production"}},
@@ -709,7 +694,7 @@ def activate(args):
     return 0
 
 
-def throttle(args):
+def allow(args):
     base_url, session = init_config(args.edgerc, args.section)
 
     command = sys.argv[1]
@@ -747,7 +732,7 @@ def throttle(args):
 
     if not force and network == "production":
         root_logger.info(
-            'You are about to throttle ' +
+            'You are about to allow traffic for ' +
             rule +
             ' at value = ' +
             str(percent) +
@@ -836,7 +821,7 @@ def throttle(args):
                             del every_match_rule['location']
                         # Match the rule name (case insensitive)
                         if rule and every_match_rule['name'].lower() == rule.lower() or args.allrules:
-                            # Update the throttle value now
+                            # Update the allow traffic percentage value now
                             rule_found = 1
                             rule_count = rule_count + 1
                             if not command == 'disable':
@@ -891,7 +876,7 @@ def throttle(args):
                 '\nTrying to create a new version of this policy with updated rule(s).')
             if policy_create_response.status_code == 200 or 201:
                 new_version = policy_create_response.json()['version']
-                # Let us now update the rules with new throttle values
+                # Let us now update the rules with new percentage values
                 policy_update_response = cloudlet_object.update_policy_version(
                     session, policy_policy_id, json.dumps(policy_details_to_modify), new_version)
                 if policy_update_response.status_code == 200:
@@ -930,12 +915,8 @@ def throttle(args):
     return 0
 
 
-def allow(args):
-    throttle(args)
-
-
 def disable(args):
-    throttle(args)
+    allow(args)
 
 
 def list(args=None):

--- a/bin/akamai-visitor-prioritization
+++ b/bin/akamai-visitor-prioritization
@@ -733,16 +733,26 @@ def allow(args):
                 return 1
 
     if not force and network == "production":
-        root_logger.info(
-            'You are about to allow traffic for ' +
-            rule +
-            ' at value = ' +
-            str(percent) +
-            ' for ' +
-            policy +
-            ' on the Akamai ' +
-            network +
-            ' network. Do you wish to continue? [y/N]')
+        if command == 'disable':
+            root_logger.info(
+                'You are about to ' + command + ' traffic for ' +
+                rule +
+                ' for ' +
+                policy +
+                ' on the Akamai ' +
+                network +
+                ' network. Do you wish to continue? [y/N]')
+        else:
+            root_logger.info(
+                'You are about to ' + command + ' traffic for ' +
+                rule +
+                ' at value = ' +
+                str(percent) +
+                ' for ' +
+                policy +
+                ' on the Akamai ' +
+                network +
+                ' network. Do you wish to continue? [y/N]')
 
 
         if str.lower(input()) != 'y':

--- a/bin/akamai-visitor-prioritization
+++ b/bin/akamai-visitor-prioritization
@@ -409,24 +409,26 @@ def show(args):
                                     # Loop each match conditon within each rule
                                     for every_match_condition in every_match_rule['matches']:
                                         if multiple_matches == 1:
-                                            root_logger.info('       AND')
+                                            root_logger.info('\n       AND\n')
                                         root_logger.info(
                                             '       Match Type: ' + every_match_condition['matchType'])
+                                        if every_match_condition['negate'] is False:
+                                            root_logger.info(
+                                                '       Match Operator: ' + every_match_condition['matchOperator'])
+                                        else:
+                                            root_logger.info(
+                                                '       Match Operator: NOT ' + every_match_condition['matchOperator'])
+
                                         if 'matchValue' in every_match_condition:
-                                            if every_match_condition['negate'] is False:
                                                 root_logger.info(
                                                     '       Match Value: ' + every_match_condition['matchValue'])
-                                            else:
-                                                root_logger.info(
-                                                    '       Match Value is NOT: ' + every_match_condition['matchValue'])
                                         elif 'objectMatchValue' in every_match_condition:
-                                            if every_match_condition['negate'] is False:
-                                                root_logger.info(
-                                                    '       Match Value: ' + str(every_match_condition['objectMatchValue']['value']))
-                                            else:
-                                                root_logger.info(
-                                                    '       Match Value is NOT: ' + str(every_match_condition['objectMatchValue']['value']))
-
+                                                if 'name' in every_match_condition['objectMatchValue']:
+                                                    root_logger.info(
+                                                        '       Match Value: ' + str(every_match_condition['objectMatchValue']['name']))
+                                                elif 'value' in every_match_condition['objectMatchValue']:
+                                                    root_logger.info(
+                                                        '       Match Value: ' + str(every_match_condition['objectMatchValue']['value']))
                                         multiple_matches = 1
                                     # Check wthether rules is disabled, if yes
                                     # display accordingly

--- a/cli.json
+++ b/cli.json
@@ -1,6 +1,6 @@
 {
   "requirements": {
-    "python": "3.1.4"
+    "python": "3.0.0"
   },
   "commands": [
     {


### PR DESCRIPTION
Change “throttle” action to be called “allow” instead
   Remove --disable from being an optional argument
   Retained “throttle” for backward compatibility


Add “disable” action
  akamai vp disable --policy policy --rule ‘rulename’ --network network

Add --allrules optional argument to both “throttle” and “disable” action
   At least of --rule or --allrules argument must exist, but error if both exist 
